### PR TITLE
Add multi-language support to pdfrename

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Leverages [pdfminer](https://github.com/pdfminer/pdfminer.six) to extract text a
 
 *Why does it add -PR.pdf to the end of filenames? Since the cost is non-zero to rename files, pdfrename needs to keep track of files which have already been renamed to avoid renaming again. I wanted something simpler than having to store a db, using filesystem attributes, or storing additional metadata files. I settled on using this suffix (-PR for (P)DF (R)ename) as a marker for renamed files.*
 
+## Multi-language Support
+
+pdfrename now supports multiple languages! The script automatically detects the language of the extracted text and adjusts the prompt accordingly. This allows for accurate filename generation in various languages.
+
 ## Usage
 
 Set your OpenAI API key in the ENV variable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 backoff==2.2.1
 openai==0.28.1
 pdfminer.six==20221105
+langdetect==1.0.9


### PR DESCRIPTION
Add support for multiple languages in `pdfrename.py`.

* **pdfrename.py**
  - Import `langdetect` for language detection.
  - Add `detect_language` function to detect the language of extracted text.
  - Modify `prompt` to include language-specific instructions.
  - Adjust `get_filename` function to use detected language.
  - Update `main` function to call `detect_language` function.

* **README.md**
  - Add section about multi-language support.
  - Update usage instructions to include language detection.

* **requirements.txt**
  - Add `langdetect` dependency.

---
